### PR TITLE
Bugfix for providing item ID's to CRUDCollection list collection

### DIFF
--- a/lib/CRUDCollection.js
+++ b/lib/CRUDCollection.js
@@ -32,7 +32,7 @@ var CRUDCollection = function(options){
     }
     if (req.app.autoLink){
       collection = collection.linkEach('self', function(item, name){
-        if (!!listOptions){
+        if (!!listOptions && !!listOptions.key){
           return req.uri.child(item[listOptions.key]);  // allow 'listOptions' to provide another key to link on.
         } else {
           return req.uri.child(name);

--- a/lib/CRUDCollection.js
+++ b/lib/CRUDCollection.js
@@ -19,7 +19,17 @@ var CRUDCollection = function(options){
   }
 
   var outputList = function(req, res, list, listOptions){
-    var collection = res.collection(list, listOptions);
+    /*
+     * listOptions : {
+     *  "key" : String, // item key attribute name
+     *  "listAsKeyedObject" : Truthy // generate list as an object with items as keyed properties, requires "key" option.
+     * }
+     */
+    if (!!listOptions && !!listOptions.key && !!listOptions.listAsKeyedObject) {
+        var collection = res.collection(list, listOptions.key);
+    } else {
+        var collection = res.collection(list);
+    }
     if (req.app.autoLink){
       collection = collection.linkEach('self', function(item, name){
         if (!!listOptions){


### PR DESCRIPTION
This patch allows listOptions.key to be provided to CRUDCollections list() function without it generating buggy output. New option listOptions.listAsKeyedObject enables listOptions.key to be optionally passed to HyperJsonCollection collection() function, switching output from an array of items to an object with items as property values and item[listOptions.key] property names. Autolink works as normal with the optional listOptions.key property.
