### PR TITLE
Fixing bug on calling CRUDCollection and other improvements.

### DIFF
--- a/lib/CRUDCollection.js
+++ b/lib/CRUDCollection.js
@@ -18,12 +18,14 @@ var CRUDCollection = function(options){
     delete options.updateSchema; // if there's no update(), we ignore any updateSchema
   }
 
-  var outputList = function(req, res, list, listOptions){
-    var collection = res.collection(list, listOptions);
+  var outputList = function (req, res, list, listOptions) {
+    var key = (listOptions) ? listOptions.key : null;
+    var objectKey = (key && listOptions.listAsKeyedObject) ? key : null;
+    var collection = res.collection(list, objectKey);
     if (req.app.autoLink){
       collection = collection.linkEach('self', function(item, name){
-        if (!!listOptions){
-          return req.uri.child(item[listOptions.key]);  // allow 'listOptions' to provide another key to link on.
+        if (key){
+          return req.uri.child(item[key].toString());  // allow 'listOptions' to provide another key to link on.
         } else {
           return req.uri.child(name);
         }


### PR DESCRIPTION
Fixes the bug when calling res.collection(items, listOptions) instead of
res.collection(items, listOptions.key)

Fixes a bug (link not generated) when the value of the key given is a falsy value

Incorporates the suggestion by Kieren on adding another option to
indicate if we want to use the key to return a keyed object. (Added
test).
